### PR TITLE
Fix compilation warnings and improve doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This project provides a Mix compiler that simplifies usage of [Erlang SNMP MIB c
 ## Installation
 
 The package can be installed by adding `mix_mib` to your list of dependencies in `mix.exs`
-and added to `compilers` list:
+and by adding `:mibs` to `compilers` list:
 
 ```elixir
 def project do
   [
     # ...
-    compilers: [:mix_mib] ++ Mix.compilers,
+    compilers: [:mibs | Mix.compilers],
     deps: [
       # ...
       {:mix_mib, "~> 1.0.0", runtime: false},

--- a/lib/mix_mib.ex
+++ b/lib/mix_mib.ex
@@ -81,6 +81,8 @@ defmodule Mix.Tasks.Compile.Mibs do
 
     if :error in results do
       Mix.raise "Encountered compilation errors"
+    else
+      :ok
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,7 @@ defmodule MixMib.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [],
+     extra_applications: [:snmp]]
   end
 end


### PR DESCRIPTION
* :snmp added to extra_applications
* compiler task must return `:ok` when everything goes well
* compiler name should be `:mibs` 